### PR TITLE
Fix Parser of FESTWERTEBLOCK to support multiline WERT

### DIFF
--- a/src/dcmReader/dcm_reader.py
+++ b/src/dcmReader/dcm_reader.py
@@ -209,9 +209,14 @@ class DcmReader:
                     found_block_parameter.y_dimension = (
                         self.convert_value(block_data.group(3)) if block_data.group(3) is not None else 1
                     )
+                    parameters = []
+                    
                     while True:
                         line = dcm_file.readline().strip()
                         if line.startswith("END"):
+                            if len(parameters) != found_block_parameter.x_dimension:
+                                logger.error("X dimension in %s do not match description!", found_block_parameter.name)
+                            found_block_parameter.values.append(parameters)
                             if len(found_block_parameter.values) != found_block_parameter.y_dimension:
                                 logger.error("Y dimension in %s do not match description!", found_block_parameter.name)
                             break
@@ -223,10 +228,7 @@ class DcmReader:
                         elif line.startswith("FUNKTION"):
                             found_block_parameter.function = self.parse_string(line)
                         elif line.startswith("WERT"):
-                            parameters = self.parse_block_parameters(line)
-                            if len(parameters) != found_block_parameter.x_dimension:
-                                logger.error("X dimension in %s do not match description!", found_block_parameter.name)
-                            found_block_parameter.values.append(parameters)
+                            parameters.extend(self.parse_block_parameters(line))
                         elif line.startswith("EINHEIT_W"):
                             found_block_parameter.unit = self.parse_string(line)
                         elif line.startswith("VAR"):


### PR DESCRIPTION
Hello,

I have a DCM file where in one of the 1D "FESTWERTBLOCK"s there are several "WERT" lines:

```
FESTWERTEBLOCK DATA_XXXXXX 7
   LANGNAME "Value to select ....."
   DISPLAYNAME XXXXXX
   FUNKTION XXXXX 
   EINHEIT_W "-"
   WERT   0.0000000000000000   0.0000000000000000   0.0000000000000000   0.0000000000000000   0.0000000000000000   0.0000000000000000   
   WERT   0.0000000000000000   
END
```

I have modified the parser to support such values.