### PR TITLE
Fix ordering parameters with minimal initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Project specific ignores
+/tests/Sample_written.dcm
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/src/dcmReader/dcm_characteristic_line.py
+++ b/src/dcmReader/dcm_characteristic_line.py
@@ -71,4 +71,14 @@ class DcmCharacteristicLine:
         return value
 
     def __lt__(self, other):
-        return self.function < other.function and self.description < other.description
+        if (
+            self.function is not None
+            and other.function is not None
+            and self.description is not None
+            and other.description is not None
+        ):
+            return (
+                self.function < other.function and self.description < other.description
+            )
+
+        return self.name < other.name

--- a/src/dcmReader/dcm_characteristic_map.py
+++ b/src/dcmReader/dcm_characteristic_map.py
@@ -87,4 +87,14 @@ class DcmCharacteristicMap:
         return value
 
     def __lt__(self, other):
-        return self.function < other.function and self.description < other.description
+        if (
+            self.function is not None
+            and other.function is not None
+            and self.description is not None
+            and other.description is not None
+        ):
+            return (
+                self.function < other.function and self.description < other.description
+            )
+
+        return self.name < other.name

--- a/src/dcmReader/dcm_parameter.py
+++ b/src/dcmReader/dcm_parameter.py
@@ -58,4 +58,14 @@ class DcmParameter:
         return value
 
     def __lt__(self, other):
-        return self.function < other.function and self.description < other.description
+        if (
+            self.function is not None
+            and other.function is not None
+            and self.description is not None
+            and other.description is not None
+        ):
+            return (
+                self.function < other.function and self.description < other.description
+            )
+
+        return self.name < other.name

--- a/src/dcmReader/dcm_parameter_block.py
+++ b/src/dcmReader/dcm_parameter_block.py
@@ -63,4 +63,14 @@ class DcmParameterBlock:
         return value
 
     def __lt__(self, other):
-        return self.function < other.function and self.description < other.description
+        if (
+            self.function is not None
+            and other.function is not None
+            and self.description is not None
+            and other.description is not None
+        ):
+            return (
+                self.function < other.function and self.description < other.description
+            )
+
+        return self.name < other.name

--- a/tests/Tests.py
+++ b/tests/Tests.py
@@ -6,7 +6,13 @@ testdir = os.path.dirname(__file__)
 srcdir = "../src"
 sys.path.insert(0, os.path.abspath(os.path.join(testdir, srcdir)))
 
-from dcmReader.dcm_reader import DcmReader, DcmParameter
+from dcmReader.dcm_reader import (
+    DcmCharacteristicLine,
+    DcmCharacteristicMap,
+    DcmReader,
+    DcmParameter,
+    DcmParameterBlock,
+)
 
 
 class TestWriteFile(unittest.TestCase):
@@ -67,10 +73,10 @@ class TestParameters(unittest.TestCase):
         self.assertEqual("ParameterB", valueParameter.variants["VariantA"])
         self.assertEqual("ParameterA", valueParameter.text)
 
-    def test_ordering_paramter_with_only_name(self):
+    def test_ordering_parameter_with_only_name(self):
         p1 = DcmParameter("p1")
         p2 = DcmParameter("p2")
-        assert p1 < p2, 'Expecting lexicographic ordering based on parameter names'
+        assert p1 < p2, 'Expecting lexicographic ordering based on names'
 
 class TestParameterBlock(unittest.TestCase):
     def test_blockParameter1D(self):
@@ -139,6 +145,10 @@ class TestParameterBlock(unittest.TestCase):
         self.assertEqual(10.5, blockParameterWritten.values[1][2])
         self.assertEqual(11.5, blockParameterWritten.values[1][3])
 
+    def test_ordering_parameter_block_with_only_name(self):
+        p1 = DcmParameterBlock("p1")
+        p2 = DcmParameterBlock("p2")
+        assert p1 < p2, 'Expecting lexicographic ordering based on names'
 
 class TestCharacteristicLines(unittest.TestCase):
     def test_characteristicLine(self):
@@ -273,6 +283,10 @@ class TestCharacteristicLines(unittest.TestCase):
         self.assertEqual("DISTRIBUTION X", characteristicWritten.x_mapping)
         self.assertEqual("Sample comment\n", characteristicWritten.comment)
 
+    def test_ordering_characteristic_line_with_only_name(self):
+        cl1 = DcmCharacteristicLine("cl1")
+        cl2 = DcmCharacteristicLine("cl2")
+        assert cl1 < cl2, 'Expecting lexicographic ordering based on names'
 
 class TestCharacteristicMaps(unittest.TestCase):
     def test_characteristicMap(self):
@@ -469,6 +483,10 @@ class TestCharacteristicMaps(unittest.TestCase):
         self.assertEqual("DISTRIBUTION Y", characteristicWritten.y_mapping)
         self.assertEqual("Sample comment\n", characteristicWritten.comment)
 
+    def test_ordering_characteristic_line_with_only_name(self):
+        cm1 = DcmCharacteristicMap("cm1")
+        cm2 = DcmCharacteristicMap("cm2")
+        assert cm1 < cm2, 'Expecting lexicographic ordering based on names'
 
 class TestDistribution(unittest.TestCase):
     def test_distribution(self):

--- a/tests/Tests.py
+++ b/tests/Tests.py
@@ -6,7 +6,7 @@ testdir = os.path.dirname(__file__)
 srcdir = "../src"
 sys.path.insert(0, os.path.abspath(os.path.join(testdir, srcdir)))
 
-from dcmReader.dcm_reader import DcmReader
+from dcmReader.dcm_reader import DcmReader, DcmParameter
 
 
 class TestWriteFile(unittest.TestCase):
@@ -67,6 +67,10 @@ class TestParameters(unittest.TestCase):
         self.assertEqual("ParameterB", valueParameter.variants["VariantA"])
         self.assertEqual("ParameterA", valueParameter.text)
 
+    def test_ordering_paramter_with_only_name(self):
+        p1 = DcmParameter("p1")
+        p2 = DcmParameter("p2")
+        assert p1 < p2, 'Expecting lexicographic ordering based on parameter names'
 
 class TestParameterBlock(unittest.TestCase):
     def test_blockParameter1D(self):


### PR DESCRIPTION
Working with `DcmParameter` I noticed that while all but the `name` attribute are optional, the sorting step that happens before writing a DCM file fails when `function` or `description` are not set. I added a test to demonstrate this behaviour in 3877d48b827dc02392f4e61e3e8ff1d695a33793 and attempted a fix in 8ab9dec5d4c07ff42e2b13d220f19813de34c8d9 that falls back to comparing names for ordering if the other attributes are unavailable to be backwards compatible. If a breaking change is acceptable, then always sorting by name could be an attractive variant since the behaviour would be more consistent then; What do you think?

This also affects the parameter block, characteristic map, and characteristic line implementations. So if you deem what I proposed for the parameter a suitable approach, then I'd also contribute corresponding changes for the other three classes in either this PR or separate PRs depending on your preference.