### PR TITLE
Fixed writing zero in parameters

### DIFF
--- a/src/dcmReader/dcm_parameter.py
+++ b/src/dcmReader/dcm_parameter.py
@@ -43,13 +43,13 @@ class DcmParameter:
             value += f"  DISPLAYNAME   {self.display_name}\n"
         if self.unit:
             value += f'  EINHEIT_W     "{self.unit}"\n'
-        if self.value:
+        if self.value is not None:
             value += f"  WERT          {self.value}\n"
         if self.text:
             value += f'  TEXT          "{self.text}"\n'
 
         for var_name, var_value in self.variants.items():
-            if self.value:
+            if self.value is not None:
                 value += f"  VAR           {var_name}={var_value}\n"
             else:
                 value += f'  VAR           {var_name}="{var_value}"\n'


### PR DESCRIPTION
Fixed writing zero in parameters by checking for None instead of truthness of self.value.
If parameter value is 0.0, self.value will be false and line "WERT 0.0" will not be printed.